### PR TITLE
Add sendMessage()

### DIFF
--- a/src/LocalRiotClientAPI.js
+++ b/src/LocalRiotClientAPI.js
@@ -100,10 +100,10 @@ class LocalRiotClientAPI {
         });
     }
     
-    sendMessage(message, pid) {
+    sendMessage(message, cid) {
         return this.axios.post('/chat/v5/messages', {
             'message': message,
-            'cid': pid,
+            'cid': cid,
         });
     }
     

--- a/src/LocalRiotClientAPI.js
+++ b/src/LocalRiotClientAPI.js
@@ -99,7 +99,14 @@ class LocalRiotClientAPI {
             'game_tag': gameTag,
         });
     }
-
+    
+    sendMessage(message, pid) {
+        return this.axios.post('/chat/v5/messages', {
+            'message': message,
+            'cid': pid,
+        });
+    }
+    
     removeFriend(puuid) {
         return this.axios.delete('/chat/v4/friends', {
             'puuid': puuid,


### PR DESCRIPTION
For sendMessage() is an open VALORANT Instance required, otherwise the message won't be send.
- The reason for that is that you will get an error on /riotgames/authenticated-connections/RANDOM-NUMBER, so i think its fixable
- The pid is your puuid + chat region (Example: 00000000-0000-0000-0000-00000000000@euw1.pvp.net).
- The pid is also in the response when you do the friend request thing where you also get the puuid from
- The two accounts have to be friends

For the other endpoints (friends) an open RiotGamesClient is enough like i have on my Windows VM because of Vanguard -.-
