### PR TITLE
Update Client Version

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -18,7 +18,7 @@ class API {
         this.user_id = null;
         this.access_token = null;
         this.entitlements_token = null;
-        this.client_version = 'release-03.00-shipping-22-574489';
+        this.client_version = 'release-03.10-shipping-19-639263';
         this.client_platform = {
             "platformType": "PC",
             "platformOS": "Windows",


### PR DESCRIPTION
i updated to new client version from https://valorant-api.com/v1/version because all endpoints threw 404 errors

i tested the module with the new version and now the requests no longer throw 404 errors

please merge this pull request and release a new npm version

i hope you like the pull request